### PR TITLE
el-formを使用して書籍登録フォームの実装

### DIFF
--- a/pages/form.vue
+++ b/pages/form.vue
@@ -29,7 +29,7 @@
         <el-button @click="submitForm('ruleForm')" type="primary"
           >Submit</el-button
         >
-        <el-button @click="resetForm('ruleForm')">Cancel</el-button>
+        <el-button @click="resetForm">Cancel</el-button>
       </el-form-item>
     </el-form>
   </div>
@@ -110,8 +110,8 @@ export default {
         }
       })
     },
-    resetForm(form) {
-      this.$refs[form].resetFields()
+    resetForm() {
+      this.$router.push('/')
     }
   }
 }

--- a/pages/form.vue
+++ b/pages/form.vue
@@ -6,20 +6,23 @@
       :rules="rules"
       label-width="120px"
     >
-      <el-form-item label="Title" prop="title">
+      <el-form-item label="タイトル" prop="title">
         <el-input v-model="ruleForm.title" />
       </el-form-item>
 
-      <el-form-item label="Author" prop="author">
+      <el-form-item label="著者" prop="author">
         <el-input v-model="ruleForm.author" />
       </el-form-item>
 
-      <el-form-item label="Price" prop="price">
+      <el-form-item label="価格" prop="price">
         <el-input v-model.number="ruleForm.price" />
       </el-form-item>
 
-      <el-form-item label="Tags" prop="tags">
-        <el-input v-model="ruleForm.tags" />
+      <el-form-item label="タグ" prop="tags">
+        <el-input
+          v-model="ruleForm.tags"
+          placeholder="スペース区切りで5つまで登録可能 "
+        />
       </el-form-item>
 
       <el-form-item>

--- a/pages/form.vue
+++ b/pages/form.vue
@@ -106,6 +106,8 @@ export default {
 
 <style scoped>
 .app-form {
+  text-align: center;
+  margin: auto;
   width: 500px;
 }
 </style>

--- a/pages/form.vue
+++ b/pages/form.vue
@@ -36,6 +36,8 @@
 </template>
 
 <script>
+import { db } from '~/plugins/firebase'
+
 export default {
   data() {
     const validateTitle = (rule, value, callback) => {
@@ -91,7 +93,18 @@ export default {
     submitForm(form) {
       this.$refs[form].validate((valid) => {
         if (valid) {
-          alert('submit!')
+          const bookRef = {
+            title: this.ruleForm.title,
+            author: this.ruleForm.author,
+            price: this.ruleForm.price,
+            tags: this.ruleForm.tags.split(' ')
+          }
+
+          db.collection('books')
+            .add(bookRef)
+            .then(() => {
+              this.$router.push('/')
+            })
         } else {
           return false
         }

--- a/pages/form.vue
+++ b/pages/form.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="app-form">
+    <el-form
+      ref="ruleForm"
+      :model="ruleForm"
+      :rules="rules"
+      label-width="120px"
+    >
+      <el-form-item label="Title" prop="title">
+        <el-input v-model="ruleForm.title" />
+      </el-form-item>
+
+      <el-form-item label="Author" prop="author">
+        <el-input v-model="ruleForm.author" />
+      </el-form-item>
+
+      <el-form-item label="Price" prop="price">
+        <el-input v-model.number="ruleForm.price" />
+      </el-form-item>
+
+      <el-form-item label="Tags" prop="tags">
+        <el-input v-model="ruleForm.tags" />
+      </el-form-item>
+
+      <el-form-item>
+        <el-button @click="submitForm('ruleForm')" type="primary"
+          >Submit</el-button
+        >
+        <el-button>Cancel</el-button>
+      </el-form-item>
+    </el-form>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    const validateTitle = (rule, value, callback) => {
+      if (!value) {
+        return callback(new Error('書籍タイトルを入力してください'))
+      }
+      callback()
+    }
+    const validateAuthor = (rule, value, callback) => {
+      if (!value) {
+        return callback(new Error('著者名を入力してください'))
+      }
+      callback()
+    }
+    const validatePrice = (rule, value, callback) => {
+      if (!value) {
+        return callback(new Error('購入価格を入力してください'))
+      }
+      if (!Number.isInteger(value)) {
+        callback(new Error('購入価格を数値で入力してください'))
+      } else if (value < 0) {
+        callback(new Error('購入価格を0以上の数値で入力してください'))
+      } else {
+        callback()
+      }
+    }
+    const checkTags = (rule, value, callback) => {
+      if (!value) {
+        return callback(new Error('タグを1つ以上入力してください'))
+      }
+      if (value.split(' ').length > 5) {
+        callback(new Error('タグの上限は5つです'))
+      } else {
+        callback()
+      }
+    }
+    return {
+      rules: {
+        title: [{ validator: validateTitle, trigger: 'blur' }],
+        author: [{ validator: validateAuthor, trigger: 'blur' }],
+        price: [{ validator: validatePrice, trigger: 'blur' }],
+        tags: [{ validator: checkTags, trigger: 'blur' }]
+      },
+      ruleForm: {
+        title: '',
+        author: '',
+        price: '',
+        tags: ''
+      }
+    }
+  },
+  methods: {
+    submitForm(form) {
+      this.$refs[form].validate((valid) => {
+        if (valid) {
+          alert('submit!')
+        } else {
+          return false
+        }
+      })
+    }
+  }
+}
+</script>
+
+<style scoped>
+.app-form {
+  width: 500px;
+}
+</style>

--- a/pages/form.vue
+++ b/pages/form.vue
@@ -27,9 +27,9 @@
 
       <el-form-item>
         <el-button @click="submitForm('ruleForm')" type="primary"
-          >Submit</el-button
+          >登録</el-button
         >
-        <el-button @click="resetForm">Cancel</el-button>
+        <el-button @click="resetForm">キャンセル</el-button>
       </el-form-item>
     </el-form>
   </div>

--- a/pages/form.vue
+++ b/pages/form.vue
@@ -26,7 +26,7 @@
         <el-button @click="submitForm('ruleForm')" type="primary"
           >Submit</el-button
         >
-        <el-button>Cancel</el-button>
+        <el-button @click="resetForm('ruleForm')">Cancel</el-button>
       </el-form-item>
     </el-form>
   </div>
@@ -93,6 +93,9 @@ export default {
           return false
         }
       })
+    },
+    resetForm(form) {
+      this.$refs[form].resetFields()
     }
   }
 }


### PR DESCRIPTION
## 概要
el-formを使用して書籍登録フォームを実装した。
el-formでの入力内容に対してバリデーションが行われ、正常なデータのみをFirestoreに送信するような仕組みとなっている。
/indexにはまだ登録フォームへのリンクは貼ってないが、URLを直接入力することでフォームページを利用することができる。