### PR TITLE
カードの縦幅を長くすることでレイアウト崩れに対応

### DIFF
--- a/components/AppBook.vue
+++ b/components/AppBook.vue
@@ -66,6 +66,7 @@ export default {
 
 .app-book-contents {
   text-align: left;
+  height: 200px;
 }
 
 .app-book-title {

--- a/components/AppBook.vue
+++ b/components/AppBook.vue
@@ -5,7 +5,7 @@
         <img :src="path" alt="icon" width="150" height="150" />
       </div>
       <div class="app-book-contents">
-        <p class="app-book-title">{{ title }}</p>
+        <p class="app-book-title">{{ bookTitle }}</p>
         <p class="app-book-author">{{ author }}</p>
         <p class="app-book-price">￥ {{ toLocalePrice }}</p>
       </div>
@@ -50,6 +50,12 @@ export default {
     },
     toLocalePrice() {
       return this.price.toLocaleString()
+    },
+    bookTitle() {
+      if (this.title.length < 24) {
+        return this.title
+      }
+      return this.title.substring(0, 22) + ' ...'
     }
   }
 }

--- a/pages/form.vue
+++ b/pages/form.vue
@@ -68,8 +68,8 @@ export default {
       if (!value) {
         return callback(new Error('タグを1つ以上入力してください'))
       }
-      if (value.split(' ').length > 5) {
-        callback(new Error('タグの上限は5つです'))
+      if (value.split(' ').length > 2) {
+        callback(new Error('タグの上限は2つです'))
       } else {
         callback()
       }


### PR DESCRIPTION
## 概要
カードの縦幅を長くすることで、レイアウト崩れに対応した。
また、タイトルの文字数が長くなってしまう場合、レイアウト崩れが予期される。
そこで、25文字以上のときは、23文字目以降を「...」と表現することで対処した。