### PR TITLE
書籍のタグをel-buttonからel-tagに変更

### DIFF
--- a/components/AppBook.vue
+++ b/components/AppBook.vue
@@ -10,14 +10,14 @@
         <p class="app-book-price">￥ {{ toLocalePrice }}</p>
       </div>
       <div style="text-align: left" class="app-book-tags">
-        <el-button
+        <el-tag
           v-for="(tag, index) in tags"
           :key="index"
-          plain
+          effect="plain"
           class="app-book-tag"
         >
           #{{ tag }}
-        </el-button>
+        </el-tag>
       </div>
     </el-card>
   </div>


### PR DESCRIPTION
## 概要
書籍のタグをel-buttonからel-tagに変更した。
el-buttonを使用して検索フォームに入力といったことを考えた場合、Vuexを使用した実装になりそうなため、実装時間省略のために今回は見送った。
そのため、タグにボタンを使用すると、「タグから直接検索できるのではないか」という思考に至ることから、ホバー時にも同じ色合いを保てるel-tagに変更した。