### PR TITLE
ストアのユーザー名にユーザーIDをセットしている間違いを修正

### DIFF
--- a/pages/home.vue
+++ b/pages/home.vue
@@ -31,7 +31,7 @@ export default {
       return
     }
 
-    this.setUsername(user.uid)
+    this.setUsername(user.displayName)
     this.$router.push('/')
   },
   methods: {


### PR DESCRIPTION
## 概要
本来であれば、user.displayNameをセットするところ、user.uidをセットしまっていたため修正を行った。