### PR TITLE
firestore.rulesにドメインを追加

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,17 +1,11 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-
-    // This rule allows anyone on the internet to view, edit, and delete
-    // all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // your app will lose access to your Firestore database
     match /{document=**} {
-      allow read, write: if request.time < timestamp.date(2020, 1, 1);
+      allow read, write: if isValidUser();
     }
+  }
+  function isValidUser() {
+      return request.auth.uid != null && request.auth.token.email.matches('.*@sakailab.info');
   }
 }


### PR DESCRIPTION
## 概要
Firestore側も「sakailab.info」のドメインに対応させるために、ルールを追加で記述した。