### PR TITLE
this.$storeとなっているコードを削除

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -35,7 +35,7 @@ export default {
     ...mapGetters({ books: 'getBooks' })
   },
   created() {
-    this.$store.dispatch('setBooks', db.collection('books'))
+    this.setBooks(db.collection('books'))
     this.filteredBooks = this.books
   },
   methods: {


### PR DESCRIPTION
## 概要
`this.$store`となっているコードはmapGettersやmapActionsと同等なため、冗長となってしまうことから削除した。

参考: https://www.code-adviser.com/detail_48091687