### PR TITLE
書籍検索オプションに閾値を追加

### DIFF
--- a/plugins/books.js
+++ b/plugins/books.js
@@ -6,6 +6,7 @@ const getFilteredBooks = (keyword, books) => {
   }
 
   const options = {
+    threshold: 0.3,
     keys: ['title', 'author', 'tags']
   }
   return new Fuse(books, options).search(keyword)


### PR DESCRIPTION
## 概要
検索時に不必要な結果まで多く出してしまうことから書籍検索オプションに閾値を追加した。
`0.3`に設定したところちょうどよい結果となった。