### PR TITLE
ホーム画面でcreatedを呼び出す時にfilteredBooksを使用するように変更

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -36,7 +36,7 @@ export default {
   },
   created() {
     this.setBooks(db.collection('books'))
-    this.filteredBooks = this.books
+    this.filteredBooks = getFilteredBooks('', this.books)
   },
   methods: {
     ...mapActions(['setBooks']),


### PR DESCRIPTION
## 概要
ホーム画面でcreatedを呼び出す時にfilteredBooksを使用するように変更した。
ソート機能を追加する際、filteredBooksに適用することが予想される。
そのため、storeのbooksを直接使用しないようにした。