### PR TITLE
書籍カードの著者・出版日テキストの修正および余白の修正

### DIFF
--- a/components/01_atoms/text/BookAuthorText.vue
+++ b/components/01_atoms/text/BookAuthorText.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="book-author-text">
-    <p>{{ author }}</p>
+    <p>{{ author }} 著</p>
   </div>
 </template>
 

--- a/components/01_atoms/text/BookPublicationDateText.vue
+++ b/components/01_atoms/text/BookPublicationDateText.vue
@@ -21,7 +21,7 @@ export default {
       const year = timestamp.getFullYear()
       const month = timestamp.getMonth() + 1
       const date = timestamp.getDate()
-      return `${year}年${month}月${date}日`
+      return `${year}年${month}月${date}日 発売`
     }
   }
 }

--- a/components/01_atoms/text/BookPublicationDateText.vue
+++ b/components/01_atoms/text/BookPublicationDateText.vue
@@ -30,6 +30,5 @@ export default {
 <style scoped>
 .book-publication-date-text {
   color: #606266;
-  font-size: 0.85rem;
 }
 </style>

--- a/components/02_molecules/card/BookCard.vue
+++ b/components/02_molecules/card/BookCard.vue
@@ -78,15 +78,11 @@ export default {
 }
 
 .book-card-author {
-  margin-bottom: 0.25rem;
-}
-
-.book-card-price {
-  margin-bottom: 0.5rem;
+  margin-bottom: 2px;
 }
 
 .book-card-publication-date {
-  margin-bottom: 0.25rem;
+  margin-bottom: 2px;
 }
 
 .book-card-tags {
@@ -97,6 +93,6 @@ export default {
 }
 
 .book-card-tag {
-  margin: 0.25rem;
+  margin-top: 25px;
 }
 </style>


### PR DESCRIPTION
## 概要
著者名には「著」を追加し、出版日に「発売」を追加した。
また、余白を修正した。