### PR TITLE
書籍APIを多重化するように変更

### DIFF
--- a/components/01_atoms/text/BookPublicationDateText.vue
+++ b/components/01_atoms/text/BookPublicationDateText.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="book-publication-date-text">
-    <p>{{ bookPublicationDate }}</p>
+    <p>{{ date }}</p>
   </div>
 </template>
 
@@ -11,17 +11,6 @@ export default {
     date: {
       type: String,
       default: ''
-    }
-  },
-  computed: {
-    bookPublicationDate() {
-      const includeDate = this.date.split('-').length - 1 === 2
-
-      if (includeDate) {
-        return this.date.replace(/(\d+)-(\d+)-(\d+)/g, '$1年$2月$3日')
-      } else {
-        return this.date.replace(/(\d+)-(\d+)/g, '$1年$2月')
-      }
     }
   }
 }

--- a/components/03_organisms/scoped/BookRegisterForm.vue
+++ b/components/03_organisms/scoped/BookRegisterForm.vue
@@ -15,9 +15,9 @@
 </template>
 
 <script>
-import { getBookFromGoogle } from '../../../plugins/books'
 import { db } from '../../../plugins/firebase'
 import IsbmImg from '../../01_atoms/icon/IsbmImg'
+import { getBookFromAPI } from '../../../plugins/books'
 
 export default {
   name: 'BookRegisterForm',
@@ -40,11 +40,11 @@ export default {
   },
   methods: {
     submit(form) {
-      this.$refs[form].validate(async (valid) => {
+      this.$refs[form].validate((valid) => {
         if (!valid) {
           return false
         }
-        await getBookFromGoogle(this.form.isbn).then((book) => {
+        getBookFromAPI(this.form.isbn).then((book) => {
           db.collection('books')
             .doc(book.id)
             .set(book)

--- a/plugins/books.js
+++ b/plugins/books.js
@@ -31,6 +31,41 @@ export const getBookFromGoogle = (isbn) => {
   })
 }
 
+export const getBookFromOpenBD = (isbn) => {
+  const url = `https://api.openbd.jp/v1/get?isbn=${isbn}`
+  return axios.get(url).then((r) => {
+    if (!r.data.length) {
+      return new Error('Unexpected ISBN')
+    }
+
+    const book = r.data[0].summary
+
+    // 取得した日付に関する操作
+    const pubDate = book.pubdate
+    let publicationDate
+    if (book.pubdate.match(/-/)) {
+      const includeDate = pubDate.split('-').length - 1 === 2
+      if (includeDate) {
+        publicationDate = pubDate.replace(/(\d+)-(\d+)-(\d+)/g, '$1年$2月$3日')
+      } else {
+        publicationDate = pubDate.replace(/(\d+)-(\d+)/g, '$1年$2月')
+      }
+    } else {
+      const year = pubDate.slice(0, 4) + '年'
+      const month = pubDate.slice(5, 7) + '月'
+      const date = pubDate.slice(8, 10) ? pubDate.slice(8, 10) + '日' : ''
+      publicationDate = year + month + date
+    }
+
+    return {
+      id: book.isbn,
+      title: book.title,
+      author: book.author.split('／')[0],
+      date: publicationDate
+    }
+  })
+}
+
 export const buildCheckedBooks = (checkedBooks, book) => {
   const setCheckedBooks = new Set(checkedBooks)
 

--- a/plugins/books.js
+++ b/plugins/books.js
@@ -32,11 +32,11 @@ const convertDate = (raw) => {
   return date
 }
 
-export const getBookFromGoogle = (isbn) => {
+const getBookFromGoogle = (isbn) => {
   const url = `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`
   return axios.get(url).then((r) => {
     if (r.data.totalItems !== 1) {
-      return new Error('Unexpected ISBN')
+      return {}
     }
 
     const book = r.data.items[0].volumeInfo
@@ -49,11 +49,11 @@ export const getBookFromGoogle = (isbn) => {
   })
 }
 
-export const getBookFromOpenBD = (isbn) => {
+const getBookFromOpenBD = (isbn) => {
   const url = `https://api.openbd.jp/v1/get?isbn=${isbn}`
   return axios.get(url).then((r) => {
-    if (!r.data.length) {
-      return new Error('Unexpected ISBN')
+    if (!r.data[0]) {
+      return {}
     }
 
     const book = r.data[0].summary
@@ -65,6 +65,18 @@ export const getBookFromOpenBD = (isbn) => {
       date: convertDate(book.pubdate)
     }
   })
+}
+
+export const getBookFromAPI = async (isbn) => {
+  const googleBookResult = await getBookFromGoogle(isbn)
+  if ('id' in googleBookResult) {
+    return googleBookResult
+  }
+
+  const openBDResult = await getBookFromOpenBD(isbn)
+  if ('id' in openBDResult.length) {
+    return openBDResult
+  }
 }
 
 export const buildCheckedBooks = (checkedBooks, book) => {

--- a/plugins/books.js
+++ b/plugins/books.js
@@ -36,7 +36,7 @@ const getBookFromGoogle = (isbn) => {
   const url = `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`
   return axios.get(url).then((r) => {
     if (r.data.totalItems !== 1) {
-      return {}
+      return false
     }
 
     const book = r.data.items[0].volumeInfo
@@ -53,7 +53,7 @@ const getBookFromOpenBD = (isbn) => {
   const url = `https://api.openbd.jp/v1/get?isbn=${isbn}`
   return axios.get(url).then((r) => {
     if (!r.data[0]) {
-      return {}
+      return false
     }
 
     const book = r.data[0].summary
@@ -69,12 +69,12 @@ const getBookFromOpenBD = (isbn) => {
 
 export const getBookFromAPI = async (isbn) => {
   const googleBookResult = await getBookFromGoogle(isbn)
-  if ('id' in googleBookResult) {
+  if (googleBookResult) {
     return googleBookResult
   }
 
   const openBDResult = await getBookFromOpenBD(isbn)
-  if ('id' in openBDResult.length) {
+  if (openBDResult) {
     return openBDResult
   }
 }


### PR DESCRIPTION
## 概要
「Google Books API」および「OpenBD API」において、どちらか片方でしか取得できないケースが多々見受けられたため、リクエストを多重化することで対応した。
書籍登録時に、「Google Books API」に対してリクエストを行い、取得できなかった場合のみ「OpenBD API」を叩くような仕組みとなっている。
どちらからも見つけられなかった場合については現状非考慮。