### PR TITLE
書籍購入者をカードに追加

### DIFF
--- a/components/01_atoms/text/BookUsernameText.vue
+++ b/components/01_atoms/text/BookUsernameText.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="book-username-text">
+    <p>{{ username }} 購入</p>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'BookUsernameText',
+  props: {
+    username: {
+      type: String,
+      default: 'Default'
+    }
+  }
+}
+</script>
+
+<style scoped>
+.book-username-text {
+  color: #606266;
+}
+</style>

--- a/components/02_molecules/card/BookCard.vue
+++ b/components/02_molecules/card/BookCard.vue
@@ -9,6 +9,7 @@
         :date="date"
         class="book-card-publication-date"
       />
+      <book-username-text :username="username" class="book-card-username" />
     </el-card>
   </div>
 </template>
@@ -18,10 +19,12 @@ import BookIcon from '../../01_atoms/icon/BookIcon'
 import BookTitleText from '../../01_atoms/text/BookTitleText'
 import BookAuthorText from '../../01_atoms/text/BookAuthorText'
 import BookPublicationDateText from '../../01_atoms/text/BookPublicationDateText'
+import BookUsernameText from '../../01_atoms/text/BookUsernameText'
 
 export default {
   name: 'BookCard',
   components: {
+    BookUsernameText,
     BookPublicationDateText,
     BookAuthorText,
     BookTitleText,
@@ -41,6 +44,10 @@ export default {
       default: ''
     },
     date: {
+      type: String,
+      default: ''
+    },
+    username: {
       type: String,
       default: ''
     }

--- a/components/03_organisms/scoped/BookCardList.vue
+++ b/components/03_organisms/scoped/BookCardList.vue
@@ -13,6 +13,7 @@
           :title="book.title"
           :author="book.author"
           :date="book.date"
+          :username="book.username"
           @checkBook="checkBooks"
           class="book-card"
         />

--- a/components/03_organisms/scoped/BookRegisterForm.vue
+++ b/components/03_organisms/scoped/BookRegisterForm.vue
@@ -88,7 +88,8 @@ export default {
           id: this.form.isbn,
           title: this.form.title,
           author: this.form.author,
-          date: dateToString(this.form.date)
+          date: dateToString(this.form.date),
+          username: this.$store.getters.getUsername
         }
 
         db.collection('books')

--- a/store/index.js
+++ b/store/index.js
@@ -26,6 +26,6 @@ export const actions = {
 
 export const getters = {
   getBooks: (state) => state.books,
-  getUserName: (state) => state.username,
+  getUsername: (state) => state.username,
   isAuthenticated: (state) => !!state.username
 }


### PR DESCRIPTION
## 概要
誰が購入した書籍であるのかを明確にするために、書籍購入者をカードに追加するようにした。
Googleに登録した名前を使用し、自動で登録される仕組みになっている。